### PR TITLE
keep separate variables for validator and mutator in handler

### DIFF
--- a/pkg/webhook/mutating_webhook.go
+++ b/pkg/webhook/mutating_webhook.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )

--- a/pkg/webhook/mutating_webhook_test.go
+++ b/pkg/webhook/mutating_webhook_test.go
@@ -2,6 +2,7 @@ package webhook_test
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/snorwin/k8s-generic-webhook/pkg/webhook"

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -81,7 +81,7 @@ func (blder *Builder) Complete(i interface{}) error {
 	}
 
 	if validator, ok := i.(Validator); ok {
-		w, err := blder.createAdmissionWebhook(&handler{Handler: validator, Object: blder.apiType})
+		w, err := blder.createAdmissionWebhook(withValidationHandler(validator, blder.apiType))
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func (blder *Builder) Complete(i interface{}) error {
 	}
 
 	if mutator, ok := i.(Mutator); ok {
-		w, err := blder.createAdmissionWebhook(&handler{Handler: mutator, Object: blder.apiType})
+		w, err := blder.createAdmissionWebhook(withMutationHandler(mutator, blder.apiType))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request solves the issue that only the validation handler is triggered if both validator and mutator interfaces are implemented in the handler struct by keeping separate instances and adding a validation to not get invalid setup.