### PR TITLE
name interface args to allow differentiate old and new object

### DIFF
--- a/pkg/webhook/mutating_webhook.go
+++ b/pkg/webhook/mutating_webhook.go
@@ -9,8 +9,8 @@ import (
 
 // Mutator specifies the interface for a generic mutating webhook.
 type Mutator interface {
-	// Mutate yields a response to an mutating AdmissionRequest.
-	Mutate(context.Context, admission.Request, runtime.Object) admission.Response
+	// Mutate yields a response to a mutating AdmissionRequest.
+	Mutate(ctx context.Context, req admission.Request, obj runtime.Object) admission.Response
 }
 
 // ensure MutatingWebhook implements Mutator

--- a/pkg/webhook/validating_webhook.go
+++ b/pkg/webhook/validating_webhook.go
@@ -9,12 +9,12 @@ import (
 
 // Validator specifies the interface for a validating webhook.
 type Validator interface {
-	// ValidateCreate yields a response to an validating AdmissionRequest with operation set to Create.
-	ValidateCreate(context.Context, admission.Request, runtime.Object) admission.Response
-	// ValidateUpdate yields a response to an validating AdmissionRequest with operation set to Update.
-	ValidateUpdate(context.Context, admission.Request, runtime.Object, runtime.Object) admission.Response
-	// ValidateDelete yields a response to an validating AdmissionRequest with operation set to Delete.
-	ValidateDelete(context.Context, admission.Request, runtime.Object) admission.Response
+	// ValidateCreate yields a response to a validating AdmissionRequest with operation set to Create.
+	ValidateCreate(ctx context.Context, req admission.Request, obj runtime.Object) admission.Response
+	// ValidateUpdate yields a response to a validating AdmissionRequest with operation set to Update.
+	ValidateUpdate(ctx context.Context, req admission.Request, obj runtime.Object, oldObj runtime.Object) admission.Response
+	// ValidateDelete yields a response to a validating AdmissionRequest with operation set to Delete.
+	ValidateDelete(ctx context.Context, req admission.Request, obj runtime.Object) admission.Response
 }
 
 // ensure ValidatingWebhook implements Validator


### PR DESCRIPTION
define interface arg names the help implementer differentiate which object is the current and which the old one