### PR TITLE
remove nil property for backwards compatibility

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -108,7 +108,6 @@ func (blder *Builder) Complete(i interface{}) error {
 func (blder *Builder) createAdmissionWebhook(handler Handler) (*admission.Webhook, error) {
 	w := &admission.Webhook{
 		Handler:         handler,
-		WithContextFunc: nil,
 	}
 
 	// inject scheme for decoder


### PR DESCRIPTION
remove nil property for backwards compatibility: github.com/konveyor/mig-controller uses an older controller-runtime which does feature `WithContextFunc` yet. The removal of the nil initialization has no effect on the functionality.