### PR TITLE
let dependabot handle github actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "k8s.io/*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
lately several github actions got updated and older versions will be deprecated.
dependabot can handle theses updates so let him do his job ;)